### PR TITLE
Update Dockerfile to an ARM64-compatible Jupyter image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM pytorch/pytorch:1.9.1-cuda11.1-cudnn8-runtime
+# Use the latest Jupyter Scipy notebook image from quay.io
+FROM quay.io/jupyter/scipy-notebook:latest
 
-LABEL author="Gus Hahn-Powell"
-LABEL description="Default container definition for class competition."
+LABEL author="Sumi Lee"
+LABEL description="Modified container definition for class competition."
 
 # Create app directory
 WORKDIR /app
 
-RUN pip install -U pytorch-lightning \
-    graphviz==0.16 \
+RUN pip install -U graphviz==0.16 \
     "ipython>=7.20.0,<8" \
     notebook==6.4.6 \
     jupyter-client==7.1.2 \


### PR DESCRIPTION
Try this to get your Jupyter running on an ARM64 chipset--I've just switched out the PyTorch Docker image for a generic Jupyter Lab image that has Scipy and some other libraries. Be sure to look at the start-up script (unchanged in the original repo) to see which port the Jupyter server will be started on. I don't think you'll need Graphviz, so if that throws an error for you, you could probably safely remove that, also.